### PR TITLE
#46 add to KtorCodegen erasing operations of a path by specific tags set

### DIFF
--- a/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/KtorCodegen.kt
+++ b/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/KtorCodegen.kt
@@ -4,6 +4,7 @@
 
 package dev.icerock.moko.network
 
+import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.servers.Server
 import org.openapitools.codegen.CodegenConstants
 import org.openapitools.codegen.CodegenOperation
@@ -55,6 +56,12 @@ class KtorCodegen : AbstractKotlinCodegen() {
 
     override fun getHelp(): String {
         return "Generates a kotlin ktor client."
+    }
+
+    override fun preprocessOpenAPI(openAPI: OpenAPI) {
+        super.preprocessOpenAPI(openAPI)
+
+        PathOperationsFilter.filterPaths(openAPI.paths)
     }
 
     override fun fromOperation(

--- a/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/PathOperationsFilter.kt
+++ b/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/PathOperationsFilter.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.network
+
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.Paths
+
+object PathOperationsFilter {
+
+    private val pathOperationsFilterSet = mutableSetOf<String>()
+
+    fun addTagToFilter(tag: String) {
+        pathOperationsFilterSet.add(tag)
+    }
+
+    internal fun filterPaths(paths: Paths?) {
+        paths?.forEach { (_, pathItem) ->
+            with(pathItem) {
+                if (get.needFilterOperation(pathOperationsFilterSet)) {
+                    get = null
+                }
+                if (put.needFilterOperation(pathOperationsFilterSet)) {
+                    put = null
+                }
+                if (post.needFilterOperation(pathOperationsFilterSet)) {
+                    post = null
+                }
+                if (delete.needFilterOperation(pathOperationsFilterSet)) {
+                    delete = null
+                }
+                if (options.needFilterOperation(pathOperationsFilterSet)) {
+                    options = null
+                }
+                if (head.needFilterOperation(pathOperationsFilterSet)) {
+                    head = null
+                }
+                if (patch.needFilterOperation(pathOperationsFilterSet)) {
+                    patch = null
+                }
+                if (trace.needFilterOperation(pathOperationsFilterSet)) {
+                    trace = null
+                }
+            }
+        }
+    }
+
+    private fun Operation?.needFilterOperation(filterTagNameSet: Set<String>): Boolean {
+        return this?.tags?.any(filterTagNameSet::contains) == true
+    }
+}


### PR DESCRIPTION
To add some tag need to call `PathOperationsFilter.addTagToFilter()`. For example, you can add tags in `MultiPlatformNetworkGeneratorPlugin` by handling some custom extension of the gradle plugin.