### PR TITLE
Allow to enable public API explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ mokoNetwork {
     spec("news") {
         inputSpec = file("src/newsApi.yaml")
         packageName = "news"
-        isInternal = false
+        apiVisibility = ApiVisibility.PUBLIC
         isOpen = true
         configureTask {
             // here can be configuration of https://github.com/OpenAPITools/openapi-generator GenerateTask

--- a/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/MultiPlatformNetworkGeneratorPlugin.kt
+++ b/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/MultiPlatformNetworkGeneratorPlugin.kt
@@ -4,6 +4,7 @@
 
 package dev.icerock.moko.network
 
+import dev.icerock.moko.network.SpecInfo.ApiVisibility
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.Delete
@@ -49,7 +50,8 @@ class MultiPlatformNetworkGeneratorPlugin : Plugin<Project> {
 
                     additionalProperties.set(
                         mutableMapOf(
-                            "nonPublicApi" to "${spec.isInternal}",
+                            "publicApi" to "${spec.apiVisibility == ApiVisibility.PUBLIC}",
+                            "nonPublicApi" to "${spec.apiVisibility == ApiVisibility.INTERNAL}",
                             "openApiClasses" to "${spec.isOpen}"
                         )
                     )

--- a/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/SpecInfo.kt
+++ b/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/SpecInfo.kt
@@ -10,9 +10,28 @@ import java.io.File
 open class SpecInfo(val name: String) {
     var inputSpec: File? = null
     var packageName: String? = "dev.icerock.moko.network.generated"
-    var isInternal = true
+    var apiVisibility = ApiVisibility.INTERNAL
     var isOpen = false
+
+    @Deprecated("Use more generic `apiVisibility` attribute", ReplaceWith("apiVisibility"))
+    var isInternal
+        get() = apiVisibility == ApiVisibility.INTERNAL
+        set(value) {
+            apiVisibility = if (value) ApiVisibility.INTERNAL else ApiVisibility.DEFAULT
+        }
+
     internal var configureTask: (GenerateTask.() -> Unit)? = null
 
     fun configureTask(block: GenerateTask.() -> Unit) { configureTask = block }
+
+    enum class ApiVisibility {
+        /** Generated classes have `public` visibility modifier. Useful for Kotlin Explicit API mode. */
+        PUBLIC,
+
+        /** Generated classes have no visibility modifier. */
+        DEFAULT,
+
+        /** Generated classes have `internal` visibility modifier. */
+        INTERNAL,
+    }
 }

--- a/plugins/network-generator/src/main/resources/kotlin-ktor-client/api.mustache
+++ b/plugins/network-generator/src/main/resources/kotlin-ktor-client/api.mustache
@@ -20,7 +20,7 @@ import io.ktor.client.call.ReceivePipelineException
 import io.ktor.http.content.TextContent
 
 {{#operations}}
-{{#openApiClasses}}open {{/openApiClasses}}{{#nonPublicApi}}internal {{/nonPublicApi}}class {{classname}}(basePath: kotlin.String = "{{{basePath}}}", httpClient: HttpClient, json: Json) {
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{#openApiClasses}}open {{/openApiClasses}}class {{classname}}(basePath: kotlin.String = "{{{basePath}}}", httpClient: HttpClient, json: Json) {
     private val _basePath = basePath
     private val _httpClient = httpClient
     private val _json = json

--- a/plugins/network-generator/src/main/resources/kotlin-ktor-client/api.mustache
+++ b/plugins/network-generator/src/main/resources/kotlin-ktor-client/api.mustache
@@ -20,7 +20,7 @@ import io.ktor.client.call.ReceivePipelineException
 import io.ktor.http.content.TextContent
 
 {{#operations}}
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{#openApiClasses}}open {{/openApiClasses}}class {{classname}}(basePath: kotlin.String = "{{{basePath}}}", httpClient: HttpClient, json: Json) {
+{{#publicApi}}public {{/publicApi}}{{#nonPublicApi}}internal {{/nonPublicApi}}{{#openApiClasses}}open {{/openApiClasses}}class {{classname}}(basePath: kotlin.String = "{{{basePath}}}", httpClient: HttpClient, json: Json) {
     private val _basePath = basePath
     private val _httpClient = httpClient
     private val _json = json
@@ -33,7 +33,7 @@ import io.ktor.http.content.TextContent
     {{/allParams}}* @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
     */{{#returnType}}
     @Suppress("UNCHECKED_CAST"){{/returnType}}
-    {{#openApiClasses}}open {{/openApiClasses}}suspend fun {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) : {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}} {
+    {{#publicApi}}public {{/publicApi}}{{#openApiClasses}}open {{/openApiClasses}}suspend fun {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) : {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}} {
         val builder = HttpRequestBuilder()
 
         builder.method = HttpMethod.{{httpMethod}}

--- a/plugins/network-generator/src/main/resources/kotlin-ktor-client/data_class.mustache
+++ b/plugins/network-generator/src/main/resources/kotlin-ktor-client/data_class.mustache
@@ -7,7 +7,7 @@ import kotlinx.serialization.SerialName
 {{/vars}}
  */
 @Serializable
-{{#nonPublicApi}}internal {{/nonPublicApi}}data class {{classname}} (
+{{#publicApi}}public {{/publicApi}}{{#nonPublicApi}}internal {{/nonPublicApi}}data class {{classname}} (
 {{#requiredVars}}
 {{>data_class_req_var}}{{^-last}},
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},
@@ -20,7 +20,7 @@ import kotlinx.serialization.SerialName
     * Values: {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
     */
     @Serializable
-    enum class {{nameInCamelCase}} {
+    {{#publicApi}}public {{/publicApi}}enum class {{nameInCamelCase}} {
     {{#allowableValues}}{{#enumVars}}
         @SerialName({{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
         {{name}}{{^-last}},{{/-last}}{{#-last}};{{/-last}}

--- a/plugins/network-generator/src/main/resources/kotlin-ktor-client/enum_class.mustache
+++ b/plugins/network-generator/src/main/resources/kotlin-ktor-client/enum_class.mustache
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 * Values: {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
 */
 @Serializable
-{{#nonPublicApi}}internal {{/nonPublicApi}}enum class {{classname}}() {
+{{#publicApi}}public {{/publicApi}}{{#nonPublicApi}}internal {{/nonPublicApi}}enum class {{classname}}() {
 {{#allowableValues}}{{#enumVars}}
     @SerialName({{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
     {{name}}{{^-last}},{{/-last}}{{#-last}};{{/-last}}

--- a/plugins/network-generator/src/main/resources/kotlin-ktor-client/model.mustache
+++ b/plugins/network-generator/src/main/resources/kotlin-ktor-client/model.mustache
@@ -7,6 +7,6 @@ import kotlinx.serialization.Serializable
 
 {{#models}}
 {{#model}}
-{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#isAlias}}typealias {{classname}} = {{dataType}}{{/isAlias}}{{^isAlias}}{{>data_class}}{{/isAlias}}{{/isEnum}}
+{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#isAlias}}{{#publicApi}}public {{/publicApi}}typealias {{classname}} = {{dataType}}{{/isAlias}}{{^isAlias}}{{>data_class}}{{/isAlias}}{{/isEnum}}
 {{/model}}
 {{/models}}


### PR DESCRIPTION
This PR adds `apiVisibility` attribute as a direct replacement for `isInternal` that allows to explicitly specify generated classes visibility as `public`. Useful when Kotlin Explicit API mode is used: https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors
