### PR TITLE
#59 workaround fix for 'open' modifier of generated api class

### DIFF
--- a/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/MultiPlatformNetworkGeneratorPlugin.kt
+++ b/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/MultiPlatformNetworkGeneratorPlugin.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
+@Suppress("ForbiddenComment")
 class MultiPlatformNetworkGeneratorPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {

--- a/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/MultiPlatformNetworkGeneratorPlugin.kt
+++ b/plugins/network-generator/src/main/kotlin/dev/icerock/moko/network/MultiPlatformNetworkGeneratorPlugin.kt
@@ -49,9 +49,15 @@ class MultiPlatformNetworkGeneratorPlugin : Plugin<Project> {
 
                     additionalProperties.set(
                         mutableMapOf(
-                            "nonPublicApi" to "${spec.isInternal}",
-                            "openApiClasses" to "${spec.isOpen}"
-                        )
+                            "nonPublicApi" to "${spec.isInternal}"
+                        ).also {
+                            // Temporary hotfix for #59
+                            // TODO: remove hotfix after approving pull-request in openapi-generator
+                            // https://github.com/OpenAPITools/openapi-generator/pull/8507
+                            if (spec.isOpen) {
+                                it["openApiClasses"] = "open "
+                            }
+                        }
                     )
 
                     outputDir.set(generatedDir)

--- a/plugins/network-generator/src/main/resources/kotlin-ktor-client/api.mustache
+++ b/plugins/network-generator/src/main/resources/kotlin-ktor-client/api.mustache
@@ -20,7 +20,7 @@ import io.ktor.client.call.ReceivePipelineException
 import io.ktor.http.content.TextContent
 
 {{#operations}}
-{{#openApiClasses}}open {{/openApiClasses}}{{#nonPublicApi}}internal {{/nonPublicApi}}class {{classname}}(basePath: kotlin.String = "{{{basePath}}}", httpClient: HttpClient, json: Json) {
+{{openApiClasses}}{{#nonPublicApi}}internal {{/nonPublicApi}}class {{classname}}(basePath: kotlin.String = "{{{basePath}}}", httpClient: HttpClient, json: Json) {
     private val _basePath = basePath
     private val _httpClient = httpClient
     private val _json = json
@@ -33,7 +33,7 @@ import io.ktor.http.content.TextContent
     {{/allParams}}* @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
     */{{#returnType}}
     @Suppress("UNCHECKED_CAST"){{/returnType}}
-    {{#openApiClasses}}open {{/openApiClasses}}suspend fun {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) : {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}} {
+    {{openApiClasses}}suspend fun {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) : {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}} {
         val builder = HttpRequestBuilder()
 
         builder.method = HttpMethod.{{httpMethod}}


### PR DESCRIPTION
Workaround for #59 